### PR TITLE
fix a capitalization error in the installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Each software application is a standalone Julia file containing all of the neces
 add Random
 add Statistics
 add CSV
-add Biosequences
+add BioSequences
 add DataFrames
 add XLSX
 add ArgParse


### PR DESCRIPTION
without this change it triggers the error message

ERROR: The following package names could not be resolved:
 * Biosequences (not found in project, manifest or registry)
   Suggestions: BioSequences